### PR TITLE
Support URL signing for multiple methods

### DIFF
--- a/tests/test_ruby-manta.rb
+++ b/tests/test_ruby-manta.rb
@@ -292,12 +292,25 @@ class TestMantaClient < MiniTest::Unit::TestCase
 
 
   def test_signed_urls
-    @@client.put_object(@@test_dir_path + '/obj1', 'foo-data')
+
+    client = HTTPClient.new
+    
+    put_url = @@client.gen_signed_url(Time.now + 500000, [:put, :options],
+                                      @@test_dir_path + '/obj1')
+
+    result = client.options("https://" + put_url, {
+      'Access-Control-Request-Headers' => 'access-control-allow-origin, accept, content-type',
+      'Access-Control-Request-Method' => 'PUT'
+    })
+
+    assert_equal result.status, 200
+
+    result = client.put("https://" + put_url, 'foo-data', { 'Content-Type' => 'text/plain' })
+    assert_equal result.status, 204
 
     url = @@client.gen_signed_url(Time.now + 500000, :get,
                                   @@test_dir_path + '/obj1')
 
-    client = HTTPClient.new
     result = client.get('http://' + url)
     assert_equal result.body, 'foo-data'
   end


### PR DESCRIPTION
Motivation: CORS file upload (http://www.w3.org/TR/cors/)

Joyent Manta supports CORS file uploads via the PUT request when the directory has the required CORS headers. The browser will send it as a preflighted request, i.e., it will first send an OPTIONS, then a PUT request. In order for this to work, we have to generate a signed URL that is valid for both requests.

node-manta has support for generating such a signature, but ruby-manta so far doesn't. This pull-request adds this functionality to ruby-manta. Now, a list of methods can be passed to the "method" parameter of gen_signed_url, and :options is regarded an allowed method.

I have adapted the test, too. It demonstrates how it is supposed to be used.
