### PR TITLE
add support for "custom" m-foo headers

### DIFF
--- a/lib/ruby-manta/manta_client.rb
+++ b/lib/ruby-manta/manta_client.rb
@@ -849,6 +849,11 @@ module RubyManta
     end
 
 
+    # :m_some_header becomes "M-Some-Header"
+    def symbol_to_header(header_symbol)
+      header_symbol.to_s.split("_").map(&:capitalize).join("-")
+    end
+
 
     # Creates headers to be given to the HTTP client and sent to the Manta
     # service. The most important is the Authorization header, without which
@@ -887,6 +892,11 @@ module RubyManta
       if origin
         raise ArgumentError unless origin == 'null' || origin =~ CORS_ORIGIN_REGEX
         headers.push([ 'Origin',  origin ])
+      end
+
+      custom_headers = opts.keys.select{|key| key.to_s.start_with? "m_" }
+      unless custom_headers.empty?
+        headers += custom_headers.map{|header_key| [ symbol_to_header(header_key), opts[header_key] ] }
       end
 
       # add md5 hash when sending data

--- a/test/unit/manta_client_test.rb
+++ b/test/unit/manta_client_test.rb
@@ -207,11 +207,14 @@ class TestMantaClient < Minitest::Test
 
     @@client.put_object(@@test_dir_path + '/obj1', 'bar-data',
                         :content_type     => 'application/wacky',
-                        :durability_level => 3)
+                        :durability_level => 3,
+                        :m_zip            => "zap"
+                       )
 
     result, headers = @@client.get_object(@@test_dir_path + '/obj1')
     assert_equal result, 'bar-data'
     assert_equal headers['Content-Type'], 'application/wacky'
+    assert_equal headers['m-zip'],        'zap'
 
     result, headers = @@client.get_object(@@test_dir_path + '/obj1', :head => true)
     assert_equal result, true


### PR DESCRIPTION
I'm nearly done with a Manta adapter for the Dragonfly gem over at https://github.com/onyxrev/dragonfly-manta_data_store

Part of the test suite for Dragonfly data stores is the ability to store arbitrary metadata in the data store.  While the Manta docs talk about m-prefixed custom metadata headers, this lib doesn't include them when storing data.

I've added the inclusion of m-foo headers and added it haphazardly to the test (there's a test that's failing but that's not a result of this work.)
